### PR TITLE
chore(circleci): ignore audit exit code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           name: NPM Audit
           command: |
             npm -v
-            npm audit
+            npm audit || true
 
   test:
     docker:

--- a/package-lock.json
+++ b/package-lock.json
@@ -791,9 +791,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.9.tgz",
-      "integrity": "sha512-Hcwhiu7zC0hD0ZPTkEE5bsK9l0z7Ou+N/mcSpYT1kq96ETMQtyZee0gjxXiAGaIHJ7wlMuUhHbYp7iAaI1965w==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.10.tgz",
+      "integrity": "sha512-IwpbRyA3AZTcM+6o/nzMtj8PWAclf239Rp4ba4EYvAl5Ks4YjBBsMbi8UMaFKWjNcfvy66fvIhPvn3F2DMhu9Q==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -806,7 +806,7 @@
         "npm": "^6.8.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
-        "registry-auth-token": "^3.3.1"
+        "registry-auth-token": "^4.0.0"
       },
       "dependencies": {
         "read-pkg": {
@@ -10161,12 +10161,12 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
+        "rc": "^1.2.8",
         "safe-buffer": "^5.0.1"
       }
     },


### PR DESCRIPTION
Ironically, these vulnerabilities come down to the `npm` package not
updating their dependencies with these fixes.

Temporarily ignore `npm audit` exit code, in order to release new
versions until npm figures things out.

nodejs/node-gyp#1717
sass/node-sass#2625